### PR TITLE
Fix: Header and footer missing on single and page templates

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","theme":"tufte-blocks"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|80"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--80)">
@@ -6,4 +6,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"tufte-blocks"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","theme":"tufte-blocks"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|80"}}},"layout":{"type":"default"}} -->
 <main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--80)">
@@ -32,4 +32,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"tufte-blocks"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
## Problem

When the theme is installed on another site, the header and footer template parts are missing on the single post and page templates.

## Root cause

`single.html` and `page.html` included `"theme":"tufte-blocks"` in their template-part blocks. Hardcoding the theme slug causes WordPress to look for template parts in a theme with that exact slug. When the theme is installed under a different directory name (e.g. `tufte-blocks-1.0.0` from a release zip), the slug won't match and the parts fail to load.

## Solution

Remove the `theme` attribute from the template-part blocks. When omitted, WordPress uses the currently active theme's template parts by default—which works regardless of installation context. This matches the working templates (`index.html`, `archive.html`, `search.html`, `404.html`), which never had the theme attribute.

## Changes

- `templates/single.html`: Remove theme attribute from header and footer template-part blocks
- `templates/page.html`: Remove theme attribute from header and footer template-part blocks

Made with [Cursor](https://cursor.com)