### PR TITLE
Remove animated underline from query loop links

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -83,23 +83,17 @@
 }
 
 /* ==========================================================================
-   Post Title Links - Match Front-End (left-to-right background-image)
+   Post Title Links - Color change only, no underline
    ========================================================================== */
 
 .editor-styles-wrapper .wp-block-post-title a {
 	color: var(--wp--preset--color--foreground);
 	text-decoration: none;
-	background-image: linear-gradient(currentColor, currentColor);
-	background-position: left bottom;
-	background-repeat: no-repeat;
-	background-size: 0% 1px;
-	transition: background-size 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-				color 0.3s ease;
+	transition: color 0.3s ease;
 }
 
 .editor-styles-wrapper .wp-block-post-title a:hover {
 	color: var(--wp--preset--color--accent, #c9a959);
-	background-size: 100% 1px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/css/links.css
+++ b/assets/css/links.css
@@ -51,6 +51,20 @@
 }
 
 /* ==========================================================================
+   Query Loop Links - No underline (color change only)
+   ========================================================================== */
+
+/**
+ * Strip the animated underline from links inside query loops.
+ * Post titles, dates, categories, excerpts get color-only hover.
+ * Paragraph links in regular content still get the full underline.
+ */
+.wp-block-query a:not(.wp-block-button__link):not(.wp-block-read-more) {
+	background-image: none !important;
+	background-size: 0 !important;
+}
+
+/* ==========================================================================
    Post Title Links (Query loop / archive titles)
    ========================================================================== */
 
@@ -61,23 +75,16 @@
 .wp-block-post-title a {
 	color: var(--wp--preset--color--foreground);
 	text-decoration: none;
-	background-image: linear-gradient(currentColor, currentColor);
-	background-position: left bottom;
-	background-repeat: no-repeat;
-	background-size: 0% 1px;
-	transition: background-size 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-				color 0.3s ease;
+	transition: color 0.3s ease;
 }
 
 .wp-block-post-title a:hover {
 	color: var(--wp--preset--color--accent, #c9a959);
-	background-size: 100% 1px;
 }
 
 .wp-block-post-title a:focus {
 	outline: 2px solid var(--wp--preset--color--primary);
 	outline-offset: 2px;
-	background-size: 100% 1px;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- Adds `.wp-block-query a:not(.wp-block-button__link):not(.wp-block-read-more)` override that strips the `background-image` animated underline from links inside query loops — post titles, dates, categories, and excerpts get color-only hover
- Excludes `.wp-block-read-more` so "Continue reading" keeps its underline
- Removes the `background-image` underline from `.wp-block-post-title a` in both `links.css` and `editor.css` (color change only)
- Paragraph links in regular post/page content are unaffected

## Test plan
- [ ] Hover post title in a query loop (homepage cards, archive) — gold color, no underline
- [ ] Hover "Continue reading" link in hero section — animated underline appears
- [ ] Hover a link inside a paragraph on a single post — animated underline still works
- [ ] Check editor matches frontend behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)